### PR TITLE
Update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-ruby '2.2.3'
+ruby '2.3.1'
 
 source "http://rubygems.org"
 


### PR DESCRIPTION
Hello JP 

while doing push app is complaining about 2.3.1 ruby version dependency 

-----> Compiling Ruby/Rack
       DEPENDENCY MISSING IN MANIFEST: ruby 2.2.3
       It looks like you're trying to use ruby 2.2.3.
       Unfortunately, that version of ruby is not supported by this buildpack.
       The versions of ruby supported in this buildpack are:
       - 2.3.1
       - 2.3.0
       - 2.2.5
       - 2.2.4
       - 2.1.9
       - 2.1.8
       If you need further help, start by reading: http://github.com/cloudfoundry/ruby-buildpack/releases.
 !
 !     exit
 !
Staging failed: Buildpack compilation step failed